### PR TITLE
Support autoload.php from WP root

### DIFF
--- a/carbon-fields-plugin.php
+++ b/carbon-fields-plugin.php
@@ -21,6 +21,8 @@ add_action( 'after_setup_theme', 'carbon_fields_boot_plugin' );
 function carbon_fields_boot_plugin() {
 	if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 		require( __DIR__ . '/vendor/autoload.php' );
+	} else if (file_exists(ABSPATH . '/vendor/autoload.php')) {
+		require_once(ABSPATH . '/vendor/autoload.php');
 	}
 	\Carbon_Fields\Carbon_Fields::boot();
 


### PR DESCRIPTION
I've worked around this issue (originally mentioned [here](https://github.com/htmlburger/carbon-fields/issues/268)) in other ways, and assumed based on previous discussions that I must have something misconfigured or am doing something wrong.  But I've just spun up a new site with Carbon Fields, everything in standard locations, and I'm convinced that I might not be the only one, and should submit a PR.

Here's the problem: I'm using CF as a plugin, installed with composer as it's supposed to be.  The directory structure is standard WP, with these relevant pieces:

`/wp-content/plugins/carbon-fields-plugin`  
`/wp-content/plugins/my-custom-plugin`  
`/vendor/autoload.php`
`/composer.json`

There's nowhere else in the codebase attempting to load the autoload.php file, because CF is currently the only composer-installed piece. The CF plugin is supposed to fill that need as I understand it, but it only checks for the autoload file in its own directory via __DIR__, which doesn't working here.  So I've added a conditional to look for the vendor/autoload file in the WordPress root, which seems like a reasonable fallback to include.

Am I missing something about the way composer should be working that this is a bad choice?