### PR TITLE
fix deprecation notice in PHP 8.3

### DIFF
--- a/core/Libraries/Plugin_Update_Warning/Plugin_Update_Warning.php
+++ b/core/Libraries/Plugin_Update_Warning/Plugin_Update_Warning.php
@@ -9,7 +9,7 @@ class Plugin_Update_Warning {
 
 	public static function instance() {
 		static $instance;
-		if ( ! is_a( $instance, get_class() ) ) {
+		if ( is_null( $instance ) ) {
 			$instance = new self();
 		}
 		return $instance;


### PR DESCRIPTION
Fix the following deprecation notice : "Calling get_class() without arguments is deprecated"